### PR TITLE
Changed device emit to send the mac address and the name of the device

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ var BluetoothScanner = module.exports = function(hcidev) {
                   var re = /((?:[0-9A-F]{2}(?::|)){6})[\t\s]+([^\n\r]+)/gmi;
 
                   while( (result = re.exec(data)) ) {
-                    self.emit('device', result);
+                    self.emit('device', result[1], result[2]);
                   }
 
                 }


### PR DESCRIPTION
Hey guys,

I noticed that you are emitting the result coming from the standard output as raw but in the README example you expect two parameters on the callback function. I made a change to the device emit and I also think that because you are using EventEmitter the way to use it should be:

var bleScanner = new Scanner(device);

bleScanner.on("device",function(mac, name) {
      console.log('Found device: ', name, ' with MAC: ', mac);
}); 

Cheers,
Elvis
